### PR TITLE
test c3p0 jdbc connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,13 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-c3p0</artifactId>
+            <version>5.3.6.Final</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,15 @@ server:
   port: 8080
   forward-headers-strategy: framework
 
+hibernate:
+  connection:
+    provider_class: org.hibernate.connection.C3P0ConnectionProvider
+  c3p0:
+    min_size: 3
+    max_size: 20
+    acquire_increment: 5
+    timeout: 1800
+
 feign:
   client:
     config:


### PR DESCRIPTION
sumber
baeldung.com/hibernate-c3p0

```
"C:\Program Files\Java\jdk-11.0.15\bin\java.exe" -javaagent:C:\Users\danie\AppData\Local\JetBrains\Toolbox\apps\IDEA-C\ch-0\231.9161.38\lib\idea_rt.jar=59747:C:\Users\danie\AppData\Local\JetBrains\Toolbox\apps\IDEA-C\ch-0\231.9161.38\bin -Dfile.encoding=UTF-8 -classpath D:\Kerja\NLE\nle_connect\target\classes;C:\Users\danie\.m2\repository\com\mchange\c3p0\0.9.5.5\c3p0-0.9.5.5.jar;C:\Users\danie\.m2\repository\com\mchange\mchange-commons-java\0.2.19\mchange-commons-java-0.2.19.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-security\2.7.1\spring-boot-starter-security-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter\2.7.1\spring-boot-starter-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-logging\2.7.1\spring-boot-starter-logging-2.7.1.jar;C:\Users\danie\.m2\repository\ch\qos\logback\logback-classic\1.2.11\logback-classic-1.2.11.jar;C:\Users\danie\.m2\repository\ch\qos\logback\logback-core\1.2.11\logback-core-1.2.11.jar;C:\Users\danie\.m2\repository\org\apache\logging\log4j\log4j-to-slf4j\2.17.2\log4j-to-slf4j-2.17.2.jar;C:\Users\danie\.m2\repository\org\apache\logging\log4j\log4j-api\2.17.2\log4j-api-2.17.2.jar;C:\Users\danie\.m2\repository\org\slf4j\jul-to-slf4j\1.7.36\jul-to-slf4j-1.7.36.jar;C:\Users\danie\.m2\repository\jakarta\annotation\jakarta.annotation-api\1.3.5\jakarta.annotation-api-1.3.5.jar;C:\Users\danie\.m2\repository\org\springframework\spring-core\5.3.21\spring-core-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\spring-jcl\5.3.21\spring-jcl-5.3.21.jar;C:\Users\danie\.m2\repository\org\yaml\snakeyaml\1.30\snakeyaml-1.30.jar;C:\Users\danie\.m2\repository\org\springframework\spring-aop\5.3.21\spring-aop-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\spring-beans\5.3.21\spring-beans-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\security\spring-security-config\5.7.2\spring-security-config-5.7.2.jar;C:\Users\danie\.m2\repository\org\springframework\spring-context\5.3.21\spring-context-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\security\spring-security-web\5.7.2\spring-security-web-5.7.2.jar;C:\Users\danie\.m2\repository\org\springframework\spring-expression\5.3.21\spring-expression-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-web\2.7.1\spring-boot-starter-web-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-json\2.7.1\spring-boot-starter-json-2.7.1.jar;C:\Users\danie\.m2\repository\com\fasterxml\jackson\datatype\jackson-datatype-jdk8\2.13.3\jackson-datatype-jdk8-2.13.3.jar;C:\Users\danie\.m2\repository\com\fasterxml\jackson\datatype\jackson-datatype-jsr310\2.13.3\jackson-datatype-jsr310-2.13.3.jar;C:\Users\danie\.m2\repository\com\fasterxml\jackson\module\jackson-module-parameter-names\2.13.3\jackson-module-parameter-names-2.13.3.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-tomcat\2.7.1\spring-boot-starter-tomcat-2.7.1.jar;C:\Users\danie\.m2\repository\org\apache\tomcat\embed\tomcat-embed-core\9.0.64\tomcat-embed-core-9.0.64.jar;C:\Users\danie\.m2\repository\org\apache\tomcat\embed\tomcat-embed-el\9.0.64\tomcat-embed-el-9.0.64.jar;C:\Users\danie\.m2\repository\org\apache\tomcat\embed\tomcat-embed-websocket\9.0.64\tomcat-embed-websocket-9.0.64.jar;C:\Users\danie\.m2\repository\org\springframework\spring-web\5.3.21\spring-web-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\spring-webmvc\5.3.21\spring-webmvc-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-data-jpa\2.7.1\spring-boot-starter-data-jpa-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-aop\2.7.1\spring-boot-starter-aop-2.7.1.jar;C:\Users\danie\.m2\repository\org\aspectj\aspectjweaver\1.9.7\aspectjweaver-1.9.7.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-jdbc\2.7.1\spring-boot-starter-jdbc-2.7.1.jar;C:\Users\danie\.m2\repository\com\zaxxer\HikariCP\4.0.3\HikariCP-4.0.3.jar;C:\Users\danie\.m2\repository\org\springframework\spring-jdbc\5.3.21\spring-jdbc-5.3.21.jar;C:\Users\danie\.m2\repository\jakarta\transaction\jakarta.transaction-api\1.3.3\jakarta.transaction-api-1.3.3.jar;C:\Users\danie\.m2\repository\jakarta\persistence\jakarta.persistence-api\2.2.3\jakarta.persistence-api-2.2.3.jar;C:\Users\danie\.m2\repository\org\hibernate\hibernate-core\5.6.9.Final\hibernate-core-5.6.9.Final.jar;C:\Users\danie\.m2\repository\net\bytebuddy\byte-buddy\1.12.11\byte-buddy-1.12.11.jar;C:\Users\danie\.m2\repository\antlr\antlr\2.7.7\antlr-2.7.7.jar;C:\Users\danie\.m2\repository\org\jboss\jandex\2.4.2.Final\jandex-2.4.2.Final.jar;C:\Users\danie\.m2\repository\org\hibernate\common\hibernate-commons-annotations\5.1.2.Final\hibernate-commons-annotations-5.1.2.Final.jar;C:\Users\danie\.m2\repository\org\glassfish\jaxb\jaxb-runtime\2.3.6\jaxb-runtime-2.3.6.jar;C:\Users\danie\.m2\repository\jakarta\xml\bind\jakarta.xml.bind-api\2.3.3\jakarta.xml.bind-api-2.3.3.jar;C:\Users\danie\.m2\repository\org\glassfish\jaxb\txw2\2.3.6\txw2-2.3.6.jar;C:\Users\danie\.m2\repository\com\sun\istack\istack-commons-runtime\3.0.12\istack-commons-runtime-3.0.12.jar;C:\Users\danie\.m2\repository\org\springframework\data\spring-data-jpa\2.7.1\spring-data-jpa-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\data\spring-data-commons\2.7.1\spring-data-commons-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\spring-orm\5.3.21\spring-orm-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\spring-tx\5.3.21\spring-tx-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\spring-aspects\5.3.21\spring-aspects-5.3.21.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-devtools\2.7.1\spring-boot-devtools-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot\2.7.1\spring-boot-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-autoconfigure\2.7.1\spring-boot-autoconfigure-2.7.1.jar;C:\Users\danie\.m2\repository\mysql\mysql-connector-java\8.0.29\mysql-connector-java-8.0.29.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-configuration-processor\2.7.1\spring-boot-configuration-processor-2.7.1.jar;C:\Users\danie\.m2\repository\org\projectlombok\lombok\1.18.24\lombok-1.18.24.jar;C:\Users\danie\.m2\repository\org\springdoc\springdoc-openapi-ui\1.6.9\springdoc-openapi-ui-1.6.9.jar;C:\Users\danie\.m2\repository\org\springdoc\springdoc-openapi-webmvc-core\1.6.9\springdoc-openapi-webmvc-core-1.6.9.jar;C:\Users\danie\.m2\repository\org\webjars\swagger-ui\4.11.1\swagger-ui-4.11.1.jar;C:\Users\danie\.m2\repository\org\webjars\webjars-locator-core\0.50\webjars-locator-core-0.50.jar;C:\Users\danie\.m2\repository\com\fasterxml\jackson\core\jackson-core\2.13.3\jackson-core-2.13.3.jar;C:\Users\danie\.m2\repository\io\github\classgraph\classgraph\4.8.147\classgraph-4.8.147.jar;C:\Users\danie\.m2\repository\org\springdoc\springdoc-openapi-security\1.6.9\springdoc-openapi-security-1.6.9.jar;C:\Users\danie\.m2\repository\org\springdoc\springdoc-openapi-common\1.6.9\springdoc-openapi-common-1.6.9.jar;C:\Users\danie\.m2\repository\io\swagger\core\v3\swagger-core\2.2.0\swagger-core-2.2.0.jar;C:\Users\danie\.m2\repository\com\fasterxml\jackson\dataformat\jackson-dataformat-yaml\2.13.3\jackson-dataformat-yaml-2.13.3.jar;C:\Users\danie\.m2\repository\io\swagger\core\v3\swagger-annotations\2.2.0\swagger-annotations-2.2.0.jar;C:\Users\danie\.m2\repository\io\swagger\core\v3\swagger-models\2.2.0\swagger-models-2.2.0.jar;C:\Users\danie\.m2\repository\org\springframework\security\spring-security-core\5.7.2\spring-security-core-5.7.2.jar;C:\Users\danie\.m2\repository\org\springframework\security\spring-security-crypto\5.7.2\spring-security-crypto-5.7.2.jar;C:\Users\danie\.m2\repository\io\jsonwebtoken\jjwt-api\0.11.5\jjwt-api-0.11.5.jar;C:\Users\danie\.m2\repository\io\jsonwebtoken\jjwt-impl\0.11.5\jjwt-impl-0.11.5.jar;C:\Users\danie\.m2\repository\io\jsonwebtoken\jjwt-jackson\0.11.5\jjwt-jackson-0.11.5.jar;C:\Users\danie\.m2\repository\com\fasterxml\jackson\core\jackson-databind\2.13.3\jackson-databind-2.13.3.jar;C:\Users\danie\.m2\repository\com\fasterxml\jackson\core\jackson-annotations\2.13.3\jackson-annotations-2.13.3.jar;C:\Users\danie\.m2\repository\org\mapstruct\mapstruct\1.5.1.Final\mapstruct-1.5.1.Final.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-mail\2.7.1\spring-boot-starter-mail-2.7.1.jar;C:\Users\danie\.m2\repository\org\springframework\spring-context-support\5.3.21\spring-context-support-5.3.21.jar;C:\Users\danie\.m2\repository\com\sun\mail\jakarta.mail\1.6.7\jakarta.mail-1.6.7.jar;C:\Users\danie\.m2\repository\com\sun\activation\jakarta.activation\1.2.2\jakarta.activation-1.2.2.jar;C:\Users\danie\.m2\repository\org\hibernate\validator\hibernate-validator\6.2.3.Final\hibernate-validator-6.2.3.Final.jar;C:\Users\danie\.m2\repository\jakarta\validation\jakarta.validation-api\2.0.2\jakarta.validation-api-2.0.2.jar;C:\Users\danie\.m2\repository\org\jboss\logging\jboss-logging\3.4.3.Final\jboss-logging-3.4.3.Final.jar;C:\Users\danie\.m2\repository\com\fasterxml\classmate\1.5.1\classmate-1.5.1.jar;C:\Users\danie\.m2\repository\io\awspring\cloud\spring-cloud-starter-aws-ses\2.3.0\spring-cloud-starter-aws-ses-2.3.0.jar;C:\Users\danie\.m2\repository\io\awspring\cloud\spring-cloud-starter-aws\2.3.0\spring-cloud-starter-aws-2.3.0.jar;C:\Users\danie\.m2\repository\io\awspring\cloud\spring-cloud-aws-context\2.3.0\spring-cloud-aws-context-2.3.0.jar;C:\Users\danie\.m2\repository\io\awspring\cloud\spring-cloud-aws-core\2.3.0\spring-cloud-aws-core-2.3.0.jar;C:\Users\danie\.m2\repository\com\amazonaws\aws-java-sdk-s3\1.11.951\aws-java-sdk-s3-1.11.951.jar;C:\Users\danie\.m2\repository\com\amazonaws\aws-java-sdk-kms\1.11.951\aws-java-sdk-kms-1.11.951.jar;C:\Users\danie\.m2\repository\com\amazonaws\aws-java-sdk-ec2\1.11.951\aws-java-sdk-ec2-1.11.951.jar;C:\Users\danie\.m2\repository\io\awspring\cloud\spring-cloud-aws-autoconfigure\2.3.0\spring-cloud-aws-autoconfigure-2.3.0.jar;C:\Users\danie\.m2\repository\io\awspring\cloud\spring-cloud-aws-ses\2.3.0\spring-cloud-aws-ses-2.3.0.jar;C:\Users\danie\.m2\repository\com\amazonaws\aws-java-sdk-ses\1.11.951\aws-java-sdk-ses-1.11.951.jar;C:\Users\danie\.m2\repository\com\amazonaws\aws-java-sdk-core\1.11.951\aws-java-sdk-core-1.11.951.jar;C:\Users\danie\.m2\repository\software\amazon\ion\ion-java\1.0.2\ion-java-1.0.2.jar;C:\Users\danie\.m2\repository\com\fasterxml\jackson\dataformat\jackson-dataformat-cbor\2.13.3\jackson-dataformat-cbor-2.13.3.jar;C:\Users\danie\.m2\repository\joda-time\joda-time\2.8.1\joda-time-2.8.1.jar;C:\Users\danie\.m2\repository\com\amazonaws\jmespath-java\1.11.951\jmespath-java-1.11.951.jar;C:\Users\danie\.m2\repository\org\slf4j\slf4j-api\1.7.36\slf4j-api-1.7.36.jar;C:\Users\danie\.m2\repository\javax\activation\javax.activation-api\1.2.0\javax.activation-api-1.2.0.jar;C:\Users\danie\.m2\repository\org\springframework\boot\spring-boot-starter-freemarker\2.7.1\spring-boot-starter-freemarker-2.7.1.jar;C:\Users\danie\.m2\repository\org\freemarker\freemarker\2.3.31\freemarker-2.3.31.jar;C:\Users\danie\.m2\repository\commons-net\commons-net\3.9.0\commons-net-3.9.0.jar;C:\Users\danie\.m2\repository\com\opencsv\opencsv\5.6\opencsv-5.6.jar;C:\Users\danie\.m2\repository\org\apache\commons\commons-lang3\3.12.0\commons-lang3-3.12.0.jar;C:\Users\danie\.m2\repository\org\apache\commons\commons-text\1.9\commons-text-1.9.jar;C:\Users\danie\.m2\repository\commons-beanutils\commons-beanutils\1.9.4\commons-beanutils-1.9.4.jar;C:\Users\danie\.m2\repository\commons-collections\commons-collections\3.2.2\commons-collections-3.2.2.jar;C:\Users\danie\.m2\repository\org\apache\commons\commons-collections4\4.4\commons-collections4-4.4.jar;C:\Users\danie\.m2\repository\org\springframework\cloud\spring-cloud-starter-openfeign\3.1.3\spring-cloud-starter-openfeign-3.1.3.jar;C:\Users\danie\.m2\repository\org\springframework\cloud\spring-cloud-starter\3.1.3\spring-cloud-starter-3.1.3.jar;C:\Users\danie\.m2\repository\org\springframework\cloud\spring-cloud-context\3.1.3\spring-cloud-context-3.1.3.jar;C:\Users\danie\.m2\repository\org\springframework\security\spring-security-rsa\1.0.10.RELEASE\spring-security-rsa-1.0.10.RELEASE.jar;C:\Users\danie\.m2\repository\org\bouncycastle\bcpkix-jdk15on\1.68\bcpkix-jdk15on-1.68.jar;C:\Users\danie\.m2\repository\org\bouncycastle\bcprov-jdk15on\1.68\bcprov-jdk15on-1.68.jar;C:\Users\danie\.m2\repository\org\springframework\cloud\spring-cloud-openfeign-core\3.1.3\spring-cloud-openfeign-core-3.1.3.jar;C:\Users\danie\.m2\repository\io\github\openfeign\form\feign-form-spring\3.8.0\feign-form-spring-3.8.0.jar;C:\Users\danie\.m2\repository\io\github\openfeign\form\feign-form\3.8.0\feign-form-3.8.0.jar;C:\Users\danie\.m2\repository\commons-fileupload\commons-fileupload\1.4\commons-fileupload-1.4.jar;C:\Users\danie\.m2\repository\org\springframework\cloud\spring-cloud-commons\3.1.3\spring-cloud-commons-3.1.3.jar;C:\Users\danie\.m2\repository\io\github\openfeign\feign-core\11.8\feign-core-11.8.jar;C:\Users\danie\.m2\repository\io\github\openfeign\feign-slf4j\11.8\feign-slf4j-11.8.jar;C:\Users\danie\.m2\repository\com\xendit\xendit-java-lib\1.21.0\xendit-java-lib-1.21.0.jar;C:\Users\danie\.m2\repository\com\google\code\findbugs\jsr305\3.0.0\jsr305-3.0.0.jar;C:\Users\danie\.m2\repository\com\google\code\gson\gson\2.9.0\gson-2.9.0.jar;C:\Users\danie\.m2\repository\org\apache\httpcomponents\httpcore\4.4.15\httpcore-4.4.15.jar;C:\Users\danie\.m2\repository\org\apache\httpcomponents\httpclient\4.5.13\httpclient-4.5.13.jar;C:\Users\danie\.m2\repository\commons-codec\commons-codec\1.15\commons-codec-1.15.jar;C:\Users\danie\.m2\repository\org\json\json\20220924\json-20220924.jar;C:\Users\danie\.m2\repository\org\apache\pdfbox\pdfbox\2.0.27\pdfbox-2.0.27.jar;C:\Users\danie\.m2\repository\org\apache\pdfbox\fontbox\2.0.27\fontbox-2.0.27.jar;C:\Users\danie\.m2\repository\commons-logging\commons-logging\1.2\commons-logging-1.2.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.xdocreport.core\2.0.4\fr.opensagres.xdocreport.core-2.0.4.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.xdocreport.document\2.0.4\fr.opensagres.xdocreport.document-2.0.4.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.xdocreport.converter\2.0.4\fr.opensagres.xdocreport.converter-2.0.4.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.xdocreport.document.docx\2.0.4\fr.opensagres.xdocreport.document.docx-2.0.4.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.xdocreport.template\2.0.4\fr.opensagres.xdocreport.template-2.0.4.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.xdocreport.template.freemarker\2.0.4\fr.opensagres.xdocreport.template.freemarker-2.0.4.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.xdocreport.converter.docx.xwpf\2.0.4\fr.opensagres.xdocreport.converter.docx.xwpf-2.0.4.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.poi.xwpf.converter.pdf\2.0.4\fr.opensagres.poi.xwpf.converter.pdf-2.0.4.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.poi.xwpf.converter.core\2.0.4\fr.opensagres.poi.xwpf.converter.core-2.0.4.jar;C:\Users\danie\.m2\repository\org\apache\poi\poi-ooxml\5.2.0\poi-ooxml-5.2.0.jar;C:\Users\danie\.m2\repository\org\apache\poi\poi\5.2.0\poi-5.2.0.jar;C:\Users\danie\.m2\repository\org\apache\commons\commons-math3\3.6.1\commons-math3-3.6.1.jar;C:\Users\danie\.m2\repository\com\zaxxer\SparseBitSet\1.2\SparseBitSet-1.2.jar;C:\Users\danie\.m2\repository\org\apache\xmlbeans\xmlbeans\5.0.3\xmlbeans-5.0.3.jar;C:\Users\danie\.m2\repository\org\apache\commons\commons-compress\1.21\commons-compress-1.21.jar;C:\Users\danie\.m2\repository\com\github\virtuald\curvesapi\1.06\curvesapi-1.06.jar;C:\Users\danie\.m2\repository\org\apache\poi\poi-ooxml-full\5.2.0\poi-ooxml-full-5.2.0.jar;C:\Users\danie\.m2\repository\org\apache\logging\log4j\log4j-core\2.17.2\log4j-core-2.17.2.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.xdocreport.itext.extension\2.0.4\fr.opensagres.xdocreport.itext.extension-2.0.4.jar;C:\Users\danie\.m2\repository\com\lowagie\itext\2.1.7\itext-2.1.7.jar;C:\Users\danie\.m2\repository\fr\opensagres\xdocreport\fr.opensagres.poi.xwpf.converter.xhtml\2.0.4\fr.opensagres.poi.xwpf.converter.xhtml-2.0.4.jar;C:\Users\danie\.m2\repository\commons-io\commons-io\2.11.0\commons-io-2.11.0.jar;C:\Users\danie\.m2\repository\com\google\zxing\core\3.4.0\core-3.4.0.jar;C:\Users\danie\.m2\repository\com\google\zxing\javase\3.4.0\javase-3.4.0.jar;C:\Users\danie\.m2\repository\com\beust\jcommander\1.72\jcommander-1.72.jar;C:\Users\danie\.m2\repository\com\github\jai-imageio\jai-imageio-core\1.4.0\jai-imageio-core-1.4.0.jar com.nle.NleBackendApplication
17:18:57.927 [Thread-0] DEBUG org.springframework.boot.devtools.restart.classloader.RestartClassLoader - Created RestartClassLoader org.springframework.boot.devtools.restart.classloader.RestartClassLoader@668e7803
2023-07-05 17:18:58.698  INFO 15604 --- [  restartedMain] o.s.b.devtools.restart.ChangeableUrls    : The Class-Path manifest attribute in C:\Users\danie\.m2\repository\com\mchange\c3p0\0.9.5.5\c3p0-0.9.5.5.jar referenced one or more files that do not exist: file:/C:/Users/danie/.m2/repository/com/mchange/c3p0/0.9.5.5/mchange-commons-java-0.2.19.jar