### PR TITLE
Test c3p0 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,9 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>com.mchange</groupId>
-            <artifactId>c3p0</artifactId>
-            <version>0.9.5.5</version>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-c3p0</artifactId>
+            <version>5.3.6.Final</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/nle/config/c3p0/C3P0DataSourceProperties.java
+++ b/src/main/java/com/nle/config/c3p0/C3P0DataSourceProperties.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Data
-@ConfigurationProperties(prefix = "demo.datasource.c3p0")
+@ConfigurationProperties(prefix = "hibernate.c3p0.datasource")
 public class C3P0DataSourceProperties {
     private String driverClassName;
     private String url;
@@ -14,8 +14,10 @@ public class C3P0DataSourceProperties {
     private String password;
     private String driverClass;
     private int initialPoolSize;
-    private int maxIdleTime;
-    private int maxPoolSize;
     private int minPoolSize;
+    private int maxPoolSize;
+    private int maxIdleTime;
     private int maxStatements;
+    private int acquireIncrement;
+    private int timeout;
 }

--- a/src/main/java/com/nle/config/c3p0/DataSourceConfig.java
+++ b/src/main/java/com/nle/config/c3p0/DataSourceConfig.java
@@ -14,13 +14,15 @@ public class DataSourceConfig {
 
         ComboPooledDataSource pooledDataSource = new ComboPooledDataSource();
 
-        pooledDataSource.setDriverClass("com.nle.config.c3p0.C3P0DataSourceProperties");
-        pooledDataSource.setUser("root");
-        pooledDataSource.setPassword("TXPSfYUiX9C4MmocXX0O");
-        pooledDataSource.setJdbcUrl("jdbc:mysql://210.247.245.143:3308/nlebackend?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true");
-        pooledDataSource.setMinPoolSize(5);
-        pooledDataSource.setMaxPoolSize(20);
-        pooledDataSource.setMaxIdleTime(1800);
+        pooledDataSource.setDriverClass(dataSourcePros.getDriverClass());
+        pooledDataSource.setUser(dataSourcePros.getUsername());
+        pooledDataSource.setPassword(dataSourcePros.getPassword());
+        pooledDataSource.setJdbcUrl(dataSourcePros.getUrl());
+        pooledDataSource.setInitialPoolSize(dataSourcePros.getInitialPoolSize());
+        pooledDataSource.setMinPoolSize(dataSourcePros.getMinPoolSize());
+        pooledDataSource.setMaxPoolSize(dataSourcePros.getMaxPoolSize());
+        pooledDataSource.setAcquireIncrement(dataSourcePros.getAcquireIncrement());
+        pooledDataSource.setCheckoutTimeout(dataSourcePros.getTimeout());
 
         return pooledDataSource;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,20 @@ server:
   port: 8080
   forward-headers-strategy: framework
 
+hibernate:
+  c3p0:
+    datasource:
+      url: jdbc:mysql://210.247.245.143:3308/nlebackend?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true
+      username: root
+      password: ${DB_PASSWORD}
+      driverClass: com.mysql.cj.jdbc.Driver
+      initialPoolSize: 5
+      minPoolSize: 5
+      maxPoolSize: 20
+      acquireIncrement: 5
+      timeout: 1800
+
+
 feign:
   client:
     config:


### PR DESCRIPTION
references
https://programmingsharing.com/configuring-c3p0-in-spring-boot-d05f92d96838

fix all config
```
2023-07-05 18:31:35.112  INFO 5756 --- [g-Init-Reporter] com.mchange.v2.log.MLog                  : MLog clients using slf4j logging.
2023-07-05 18:31:35.410  INFO 5756 --- [  restartedMain] com.mchange.v2.c3p0.C3P0Registry         : Initializing c3p0-0.9.5.5 [built 11-December-2019 22:18:33 -0800; debug? true; trace: 10]
2023-07-05 18:31:35.918  INFO 5756 --- [  restartedMain] c.m.v.c.i.AbstractPoolBackedDataSource   : Initializing c3p0 pool... com.mchange.v2.c3p0.ComboPooledDataSource [ acquireIncrement -> 5, acquireRetryAttempts -> 30, acquireRetryDelay -> 1000, autoCommitOnClose -> false, automaticTestTable -> null, breakAfterAcquireFailure -> false, checkoutTimeout -> 1800, connectionCustomizerClassName -> null, connectionTesterClassName -> com.mchange.v2.c3p0.impl.DefaultConnectionTester, contextClassLoaderSource -> caller, dataSourceName -> 1hge0yvaxahsk992jz26s|68577ed2, debugUnreturnedConnectionStackTraces -> false, description -> null, driverClass -> com.mysql.cj.jdbc.Driver, extensions -> {}, factoryClassLocation -> null, forceIgnoreUnresolvedTransactions -> false, forceSynchronousCheckins -> false, forceUseNamedDriverClass -> false, identityToken -> 1hge0yvaxahsk992jz26s|68577ed2, idleConnectionTestPeriod -> 0, initialPoolSize -> 5, jdbcUrl -> jdbc:mysql://210.247.245.143:3308/nlebackend?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true, maxAdministrativeTaskTime -> 0, maxConnectionAge -> 0, maxIdleTime -> 0, maxIdleTimeExcessConnections -> 0, maxPoolSize -> 20, maxStatements -> 0, maxStatementsPerConnection -> 0, minPoolSize -> 5, numHelperThreads -> 3, preferredTestQuery -> null, privilegeSpawnedThreads -> false, properties -> {password=******, user=******}, propertyCycle -> 0, statementCacheNumDeferredCloseThreads -> 0, testConnectionOnCheckin -> false, testConnectionOnCheckout -> false, unreturnedConnectionTimeout -> 0, userOverrides -> {}, usesTraditionalReflectiveProxies -> false ]
2023-07-05 18:31:36.959  INFO 5756 --- [  restartedMain] o.hibernate.jpa.internal.util.LogHelper  : HHH000204: Processing PersistenceUnitInfo [name: default]
```